### PR TITLE
Move ava and xo to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,17 +23,15 @@
 		"cli",
 		"test"
 	],
-	"dependencies": {
-		"ava": "^1.3.1",
-		"xo": "^0.24.0"
-	},
 	"devDependencies": {
+		"ava": "^1.3.1",
 		"@babel/preset-react": "^7.0.0",
 		"eslint-config-xo-react": "^0.19.0",
 		"eslint-plugin-react": "^7.12.4",
 		"eslint-plugin-react-hooks": "^1.4.0",
 		"ink": "^2.0.3",
-		"react": "^16.8.4"
+		"react": "^16.8.4",
+		"xo": "^0.24.0"
 	},
 	"babel": {
 		"presets": [


### PR DESCRIPTION
Since ava and xo are not used at run time, they should be devDependencies.