### PR TITLE
Added a createRender wrapper function to allow import mocking of ink

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ const createStdin = () => {
 
 const instances = [];
 
-exports.render = tree => {
+const createRender = realRender => tree => {
 	const stdout = createStdout();
 	const stdin = createStdin();
 
@@ -57,6 +57,9 @@ exports.render = tree => {
 		lastFrame: stdout.lastFrame
 	};
 };
+
+exports.render = createRender(render);
+exports.createRender = createRender;
 
 exports.cleanup = () => {
 	for (const instance of instances) {

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ const createRender = realRender => tree => {
 	const stdout = createStdout();
 	const stdin = createStdin();
 
-	const instance = render(tree, {
+	const instance = realRender(tree, {
 		stdout,
 		stdin,
 		debug: true,

--- a/readme.md
+++ b/readme.md
@@ -135,9 +135,9 @@ const {stdin} = render(tree);
 stdin.write('hello');
 ```
 
-### createRender()
+### createRender(render)
 
-A `createRender` function is also exported to allow you to mock Ink's render function and replace it with the one from this library when using testing libraries such as Jest. This is useful for more integration style tests as it allows you to assert what was rendered without direct access to the return value of `render()`.
+A `createRender` function is also exported can be used to mock Ink's render function and replace it with the one from this library when using testing libraries such as Jest. This is useful for more integration style tests as it allows you to assert what was rendered without direct access to the return value of `render()`.
 
 e.g. 
 

--- a/readme.md
+++ b/readme.md
@@ -135,6 +135,40 @@ const {stdin} = render(tree);
 stdin.write('hello');
 ```
 
+### createRender()
+
+A `createRender` function is also exported to allow you to mock Ink's render function and replace it with the one from this library when using testing libraries such as Jest. This is useful for more integration style tests as it allows you to assert what was rendered without direct access to the return value of `render()`.
+
+e.g. 
+
+When using Jest creating a file named `__mocks__/tin.js` in the same folder containing your `node_modules` will replace Ink's render function for all of your tests.
+
+```jsx
+import { createRender } from "ink-testing-library";
+
+const ink = jest.requireActual("ink");
+
+module.exports = {
+  ...ink,
+  render: jest.fn(createRender(ink.render))
+};
+
+```
+
+```jsx
+import React from "react";
+import { render } from "ink";
+
+import prog from "main"
+
+it("shows the config", () => {
+  prog.parse("config show");
+  
+  render.mock.results[0].value.lastFrame() // Output from the first render call
+});
+```
+
+This is nessesary because under the hood Ink Testing Library uses Ink's real `render()` function. Attempting to mock `ink.render()` while using ITL will cause ITL's `render()` function to use the newly mocked `ink.render()`.
 
 ## License
 


### PR DESCRIPTION
The current structure of ink-testing-library means that it's not possible to use something like Jest's import mocking. 

e.g.

```javascript
jest.mock("ink", () => {
  const inkTesting = require("ink-testing-library");

  return { render: inkTesting.render };
});
```

Won't work because ink-testing-library tries to import the render function from ink... which is now mocked.

This change allows a solution to this, e.g.

```javascript
jest.mock("ink", () => {
  const inkTesting = require("ink-testing-library");
  const { render: realRender } = jest.requireActual("ink");

  return { render: inkTesting.createRender(realRender) };
});
```

Now anywhere the render function from ink is used it is replaced with the one from ink-testing-library but ink-testing-library itself still gets the real render function.

The motivation for this is to allow me to test from the outside of the app, without changing the interface of my code just to support the tests.

e.g.

```javascript
import React from "react";
import { render } from "ink";

import Config from "./Config" 

export default async prog => {
  prog
    .command("config show", "Show your local config")
    .action(() => render(<Config />));
}
```

Can not be tested without changing the interface.