### PR TITLE
send keypress to stdin

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,11 +23,14 @@ const createStdout = () => {
 
 const createStdin = () => {
 	const stdin = new EventEmitter();
+
 	stdin.setEncoding = () => {};
 	stdin.setRawMode = () => {};
 	stdin.resume = () => {};
 	stdin.pause = () => {};
+
 	stdin.write = data => stdin.emit('data', data);
+	stdin.keypress = name => stdin.emit('keypress', '', {name});
 
 	return stdin;
 };
@@ -51,7 +54,8 @@ exports.render = tree => {
 		rerender: instance.rerender,
 		unmount: instance.unmount,
 		stdin: {
-			write: stdin.write
+			write: stdin.write,
+			keypress: stdin.keypress
 		},
 		frames: stdout.frames,
 		lastFrame: stdout.lastFrame

--- a/test.js
+++ b/test.js
@@ -92,3 +92,42 @@ test('write to stdin', t => {
 
 	t.is(lastFrame(), 'Hello World');
 });
+
+test('send keypress to stdin', t => {
+	class Test extends React.Component {
+		constructor() {
+			super();
+
+			this.state = {
+				lastKeyPressed: ''
+			};
+		}
+
+		render() {
+			return <Text>{this.state.lastKeyPressed}</Text>;
+		}
+
+		componentDidMount() {
+			this.props.setRawMode(true);
+			this.props.stdin.on('keypress', (ch, key) => {
+				this.setState({
+					lastKeyPressed: key.name
+				});
+			});
+		}
+	}
+
+	const {stdin, lastFrame} = render((
+		<StdinContext.Consumer>
+			{({stdin, setRawMode}) => (
+				<Test stdin={stdin} setRawMode={setRawMode}/>
+			)}
+		</StdinContext.Consumer>
+	));
+
+	t.is(lastFrame(), '');
+
+	stdin.keypress('escape');
+
+	t.is(lastFrame(), 'escape');
+});


### PR DESCRIPTION
I thought this might be helpful. You wouldn't have to bother about escape character sequences and tests should be more readable.

Not sure though whether
```javascript
stdin.keypress = name => stdin.emit('keypress', '', {name});
```
or
```javascript
stdin.keypress = key => stdin.emit('keypress', '', key);
```
or even
```javascript
stdin.keypress = (ch, key) => stdin.emit('keypress', ch, key);
```
?

What do you think?