### PR TITLE
Add isTTY to dummy stdin

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const createStdin = () => {
 	stdin.resume = () => {};
 	stdin.pause = () => {};
 	stdin.write = data => stdin.emit('data', data);
+	stdin.isTTY = true;
 
 	return stdin;
 };


### PR DESCRIPTION
After vadimdemedes/ink#172 was merged, Ink's Inputs renders
differently when in TTY mode. Without this change, there is no
output in `lastFrame` from Input elements.