### PR TITLE
Add TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+export interface MockStdIn {
+  write(str: string): void;
+}
+
+export interface Helpers<P> {
+  rerender<P>(tree: React.ReactElement<P>): void;
+  unmount(): void;
+  stdin: MockStdIn;
+  frames: Array<string>
+  lastFrame(): string;
+}
+
+export function render<P>(node: React.ReactElement<P>): Helpers<P>;
+
+export function cleanup(): void;

--- a/index.test-d.tsx
+++ b/index.test-d.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+import { Box } from "ink";
+import { render } from ".";
+import { expectType } from "tsd";
+
+const helpers = render<{}>(<Box>Rendered!</Box>);
+
+helpers.rerender(<Box>Updated!</Box>);
+helpers.stdin.write("Hello");
+expectType<Array<string>>(helpers.frames);
+expectType<string>(helpers.lastFrame());
+
+helpers.unmount();

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ava && tsd"
 	},
+	"types": "index.d.ts",
 	"files": [
+		"index.d.ts",
 		"index.js"
 	],
 	"keywords": [
@@ -24,13 +26,14 @@
 		"test"
 	],
 	"devDependencies": {
-		"ava": "^1.3.1",
 		"@babel/preset-react": "^7.0.0",
+		"ava": "^1.3.1",
 		"eslint-config-xo-react": "^0.19.0",
 		"eslint-plugin-react": "^7.12.4",
 		"eslint-plugin-react-hooks": "^1.4.0",
 		"ink": "^2.0.3",
 		"react": "^16.8.4",
+		"tsd": "^0.11.0",
 		"xo": "^0.24.0"
 	},
 	"babel": {


### PR DESCRIPTION
Most Ink packages are shipping their own types, and the DT ones depend on Ink <1.0.0, so might be worth pulling these in as well. These are sourced from the types I wrote for my own use.