### PR TITLE
Move types packages out of `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,13 @@
 		"cli",
 		"test"
 	],
-	"dependencies": {
-		"@types/node": "^14.0.13",
-		"@types/react": "^16.9.38"
-	},
+	"dependencies": {},
 	"devDependencies": {
 		"@ava/babel": "^1.0.1",
 		"@babel/preset-react": "^7.0.0",
 		"@sindresorhus/tsconfig": "^0.7.0",
+		"@types/node": "^14.0.13",
+		"@types/react": "^16.9.38",
 		"ava": "^3.9.0",
 		"delay": "^4.3.0",
 		"eslint-config-xo-react": "^0.19.0",
@@ -45,6 +44,14 @@
 		"react": "^16.8.4",
 		"typescript": "^3.9.5",
 		"xo": "^0.32.0"
+	},
+	"peerDependencies": {
+		"@types/react": ">=16.8.0"
+	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
 	},
 	"ava": {
 		"babel": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
 		"cli",
 		"test"
 	],
-	"dependencies": {},
 	"devDependencies": {
 		"@ava/babel": "^1.0.1",
 		"@babel/preset-react": "^7.0.0",


### PR DESCRIPTION
Bit of an extension of https://github.com/vadimdemedes/ink/issues/320. I've made the constraint for `@types/react` technically a little lower than what it was, so that it now matches what `ink` requires - if that breaks it then it should be changed in `ink` too.

Also, look, no dependencies! 🎉 