### PR TITLE
Fix: VSCode cannot find package typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"url": "https://github.com/vadimdemedes"
 	},
 	"type": "module",
+	"types": "./build/index.d.ts",
 	"exports": {
 		"types": "./build/index.d.ts",
 		"default": "./build/index.js"


### PR DESCRIPTION
### Issue: 

VS code couldn't find the typings of the project. 

https://github.com/vadimdemedes/ink-testing-library/assets/9442803/945c9046-9cf7-4e67-ba99-21bb3db0dd98

### What Has Been Done:

I used the `types` attribute in package.json to ensure Vscode find the typings.
Source: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package




