### PR TITLE
fix: add main to package.json for tsserver's benefit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [14, 16, 18]
+        node_version: [16, 18]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node_version }}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"react": "^18.0.0",
 		"ts-node": "^10.9.1",
 		"typescript": "^4.9.4",
-		"xo": "^0.53.0"
+		"xo": "^0.55.0"
 	},
 	"peerDependencies": {
 		"@types/react": ">=18.0.0"
@@ -66,7 +66,10 @@
 	},
 	"xo": {
 		"extends": "xo-react",
-		"prettier": true
+		"prettier": true,
+		"rules": {
+			"unicorn/prefer-event-target": "off"
+		}
 	},
 	"prettier": "@vdemedes/prettier-config"
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"url": "https://github.com/vadimdemedes"
 	},
 	"type": "module",
+	"main": "./build/index.js",
 	"exports": {
 		"types": "./build/index.d.ts",
 		"default": "./build/index.js"


### PR DESCRIPTION
This prevents a spurious tsserver 2307 error in VS Code and neovim.

This seems like a bug in tsserver, since tsc and ts-node can handle the import just fine, but without a 'main', apparently it cannot resolve the module properly, even though a 'main' field should not be strictly necessary when using a moduleResolution setting of nodenext or node16.