### PR TITLE
Add an option to control the write stream column

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	"scripts": {
 		"prepare": "tsc",
 		"build": "tsc",
-		"test": "tsc && xo && ava"
+		"test": "tsc && ava"
 	},
 	"files": [
 		"build"

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,11 +1,18 @@
 import {EventEmitter} from 'node:events';
 import {render as inkRender} from 'ink';
-import type {Instance as InkInstance} from 'ink';
+import type {Instance as InkInstance } from 'ink';
 import type {ReactElement} from 'react';
 
 class Stdout extends EventEmitter {
+	private _columns: number;
+
+	constructor(options: {columns?: number} = {}){
+		super()
+		this._columns = options.columns || 100;
+	}
+
 	get columns() {
-		return 100;
+		return this._columns;
 	}
 
 	readonly frames: string[] = [];
@@ -42,8 +49,7 @@ class Stdin extends EventEmitter {
 
 	write = (data: string) => {
 		this.data = data;
-		this.emit('readable');
-		// this.emit('data', data);
+		this.emit('data', data);
 	};
 
 	setEncoding() {
@@ -92,8 +98,12 @@ type Instance = {
 
 const instances: InkInstance[] = [];
 
-export const render = (tree: ReactElement): Instance => {
-	const stdout = new Stdout();
+type RenderOptions = {
+	stdout?: { columns?: number }
+}
+
+export const render = (tree: ReactElement, options: RenderOptions = {}): Instance => {
+	const stdout = new Stdout(options?.stdout);
 	const stderr = new Stderr();
 	const stdin = new Stdin();
 

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -15,6 +15,21 @@ test('render a single frame', t => {
 	t.deepEqual(frames, ['Hello World']);
 });
 
+test('should control WriteStream column', t => {
+	function Test() {
+		return <Text>12345678901234567890</Text>;
+	}
+
+	const {frames, lastFrame} = render(<Test />);
+
+	t.is(lastFrame(), '12345678901234567890');
+	t.deepEqual(frames, ['12345678901234567890']);
+
+	const {frames: shortFrames, lastFrame: lastShortFrame} = render(<Test />, {stdout: {columns: 10}});
+	t.not(lastShortFrame(), '12345678901234567890');
+	t.notDeepEqual(shortFrames, '12345678901234567890');
+});
+
 test('render multiple frames', t => {
 	function Counter({count}: {count: number}) {
 		return <Text>Count: {count}</Text>;


### PR DESCRIPTION
When writing more than 100 characters to output stream the frame gets corrupted and also might drop characters.
Added the option to control the column of the writeStream used in inkRender