### PR TITLE
Create waitFor and renderHook utility functions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,40 @@ const {unmount} = render(<Test/>);
 unmount();
 ```
 
+#### renderHook(hook, options)
+
+Type: `function`
+
+Arguments:
+- `hook` (`function`): Hook to render.
+- `options` (`object`): Options object with the following properties:
+	- `wrapper` (`function`): Wrapper component to wrap the hook with.
+
+Render a hook with an optional wrapper, and return the hook's return value. Works like react-testing-library's `renderHook`.
+
+```jsx
+const useCounter = () => {
+	const [count, setCount] = React.useState(0);
+	return {count, increment: () => setCount(count + 1)};
+};
+
+const {result} = renderHook(() => useCounter());
+```
+
+#### waitFor(condition, timeout, interval)
+
+Type: `function`
+Arguments:
+- `condition` (`function`): Function that throws an error if the condition is not met.
+- `timeout` (`number`): Timeout in milliseconds.
+- `interval` (`number`): Interval in milliseconds.
+
+Wait for a condition to be met. Useful for waiting for side effects. The condition can be jest's `expect` assertion. Works like react-testing-library's `waitFor`.
+
+```jsx
+await waitFor(() => expect(result.current.count).toBe(1));
+```
+
 #### stdin
 
 Type: `object`

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import test from 'ava';
 import {Text, useStdin, useStderr} from 'ink';
 import delay from 'delay';
-import {render} from '../source/index.js';
+import {render, renderHook, waitFor} from '../source/index.js';
 
 test('render a single frame', t => {
 	function Test() {
@@ -131,4 +131,34 @@ test('write to stderr', async t => {
 	t.is(lastFrame(), 'Output');
 	await delay(100);
 	t.is(stderr.lastFrame(), 'Hello World');
+});
+
+test('render a hook', async t => {
+	const useCount = () => {
+		const [count, setCount] = React.useState(0);
+
+		return {
+			count,
+			increment() {
+				setCount(previousCount => previousCount + 1);
+			},
+		};
+	};
+
+	const {result} = renderHook(() => useCount());
+	await waitFor(() => {
+		if(result.current === undefined) {
+			throw new Error('Result is still undefined');
+		}
+	});
+
+	result.current.increment();
+
+	await waitFor(() => {
+		if(result.current.count !== 1) {
+			throw new Error('Count is not 1');
+		}
+	});
+
+	t.pass();
 });

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -147,7 +147,7 @@ test('render a hook', async t => {
 
 	const {result} = renderHook(() => useCount());
 	await waitFor(() => {
-		if(result.current === undefined) {
+		if (result.current === undefined) {
 			throw new Error('Result is still undefined');
 		}
 	});
@@ -155,7 +155,7 @@ test('render a hook', async t => {
 	result.current.increment();
 
 	await waitFor(() => {
-		if(result.current.count !== 1) {
+		if (result.current.count !== 1) {
 			throw new Error('Count is not 1');
 		}
 	});


### PR DESCRIPTION
Hi, I ended up needing some utils to test my ink program properly, so I thought I might as well submit them here: `waitFor`, and `renderHook`. They're designed to resemble their React Testing Library counterparts.

I also added a test using them both, and added documentation to the readme.

Unfortunately, `waitFor` won't work with ava assertions, because as far as I can tell, once an assertion fails, that's it for the test. And using this function, you just keep waiting in a loop and check every now and then if your assertion passes. It works with jest's `expect` though, and it works if you simply pass an error-throwing function then use `t.pass()` at the end of the test, so that's what I did.

I hope this will help others using this library. Let me know if I can improve anything.