### PR TITLE
Add frame-driven waitFor utility

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,35 @@ const {unmount} = render(<Test/>);
 unmount();
 ```
 
+#### waitFor(assertion, options?)
+
+Type: `function`
+
+Wait for an assertion to pass, re-checking each time a new frame is rendered. If the assertion doesn't pass within the timeout, the returned promise rejects with the last assertion error.
+
+##### assertion
+
+Type: `function`
+
+Function that throws an error when the expected condition is not met.
+
+##### options.timeout
+
+Type: `number`\
+Default: `1000`
+
+Maximum time in milliseconds to wait for the assertion to pass.
+
+```jsx
+const {lastFrame, waitFor} = render(<MyApp/>);
+
+await waitFor(() => {
+	if (lastFrame() !== 'Hello World') {
+		throw new Error('Expected "Hello World"');
+	}
+});
+```
+
 #### stdin
 
 Type: `object`

--- a/source/index.ts
+++ b/source/index.ts
@@ -13,6 +13,7 @@ class Stdout extends EventEmitter {
 	write = (frame: string) => {
 		this.frames.push(frame);
 		this._lastFrame = frame;
+		this.emit('frame');
 	};
 
 	lastFrame = () => this._lastFrame;
@@ -25,6 +26,7 @@ class Stderr extends EventEmitter {
 	write = (frame: string) => {
 		this.frames.push(frame);
 		this._lastFrame = frame;
+		this.emit('frame');
 	};
 
 	lastFrame = () => this._lastFrame;
@@ -77,6 +79,10 @@ class Stdin extends EventEmitter {
 	};
 }
 
+type WaitForOptions = {
+	timeout?: number;
+};
+
 type Instance = {
 	rerender: (tree: ReactElement) => void;
 	unmount: () => void;
@@ -86,6 +92,8 @@ type Instance = {
 	stdin: Stdin;
 	frames: string[];
 	lastFrame: () => string | undefined;
+
+	waitFor: (assertion: () => void, options?: WaitForOptions) => Promise<void>;
 };
 
 const instances: InkInstance[] = [];
@@ -118,6 +126,7 @@ export const render = (tree: ReactElement): Instance => {
 		stdin,
 		frames: stdout.frames,
 		lastFrame: stdout.lastFrame,
+		waitFor: createWaitFor(stdout),
 	};
 };
 
@@ -127,3 +136,41 @@ export const cleanup = () => {
 		instance.cleanup();
 	}
 };
+
+function createWaitFor(
+	stdout: Stdout,
+): (assertion: () => void, options?: WaitForOptions) => Promise<void> {
+	return async (assertion, options) => {
+		const {timeout = 1000} = options ?? {};
+
+		let lastError: Error | undefined;
+
+		// Check immediately — the frame may already be there.
+		try {
+			assertion();
+			return;
+		} catch (error: unknown) {
+			lastError = error instanceof Error ? error : new Error(String(error));
+		}
+
+		return new Promise<void>((resolve, reject) => {
+			const timer = setTimeout(() => {
+				stdout.off('frame', onFrame);
+				reject(lastError ?? new Error('waitFor timed out'));
+			}, timeout);
+
+			function onFrame() {
+				try {
+					assertion();
+					clearTimeout(timer);
+					stdout.off('frame', onFrame);
+					resolve();
+				} catch (error: unknown) {
+					lastError = error instanceof Error ? error : new Error(String(error));
+				}
+			}
+
+			stdout.on('frame', onFrame);
+		});
+	};
+}

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -108,11 +108,16 @@ test('write to stdin', async t => {
 		return <Text>{input}</Text>;
 	}
 
-	const {stdin, lastFrame} = render(<Test />);
+	const {stdin, lastFrame, waitFor} = render(<Test />);
 	t.is(lastFrame(), '');
-	await delay(100);
+	// Let useEffect set up the stdin listener before writing.
+	await delay(0);
 	stdin.write('Hello World');
-	await delay(100);
+	await waitFor(() => {
+		if (lastFrame() !== 'Hello World') {
+			throw new Error(`Expected "Hello World", got "${lastFrame()}"`);
+		}
+	});
 	t.is(lastFrame(), 'Hello World');
 });
 
@@ -127,8 +132,116 @@ test('write to stderr', async t => {
 		return <Text>Output</Text>;
 	}
 
-	const {stderr, lastFrame} = render(<Test />);
+	const {stderr, lastFrame, waitFor} = render(<Test />);
 	t.is(lastFrame(), 'Output');
-	await delay(100);
+	await waitFor(() => {
+		if (stderr.lastFrame() !== 'Hello World') {
+			throw new Error(`Expected "Hello World", got "${stderr.lastFrame()}"`);
+		}
+	});
 	t.is(stderr.lastFrame(), 'Hello World');
+});
+
+test('waitFor resolves immediately if assertion already passes', async t => {
+	function Test() {
+		return <Text>Already here</Text>;
+	}
+
+	const {lastFrame, waitFor} = render(<Test />);
+	await waitFor(() => {
+		if (lastFrame() !== 'Already here') {
+			throw new Error('not yet');
+		}
+	});
+	t.is(lastFrame(), 'Already here');
+});
+
+test('waitFor waits for useEffect state update', async t => {
+	function Test() {
+		const [ready, setReady] = React.useState(false);
+		React.useEffect(() => {
+			setReady(true);
+		}, []);
+		return <Text>{ready ? 'ready' : 'init'}</Text>;
+	}
+
+	const {lastFrame, waitFor} = render(<Test />);
+	await waitFor(() => {
+		if (lastFrame() !== 'ready') {
+			throw new Error(`Expected "ready", got "${lastFrame()}"`);
+		}
+	});
+	t.is(lastFrame(), 'ready');
+});
+
+test('waitFor waits for cascading effects', async t => {
+	function Test() {
+		const [step, setStep] = React.useState(0);
+		React.useEffect(() => {
+			if (step < 3) {
+				setStep(s => s + 1);
+			}
+		}, [step]);
+		return <Text>step-{step}</Text>;
+	}
+
+	const {lastFrame, waitFor} = render(<Test />);
+	await waitFor(() => {
+		if (lastFrame() !== 'step-3') {
+			throw new Error(`Expected "step-3", got "${lastFrame()}"`);
+		}
+	});
+	t.is(lastFrame(), 'step-3');
+});
+
+test('waitFor waits for promise-based state update', async t => {
+	function Test() {
+		const [data, setData] = React.useState('loading');
+		React.useEffect(() => {
+			void Promise.resolve('fetched').then(setData);
+		}, []);
+		return <Text>{data}</Text>;
+	}
+
+	const {lastFrame, waitFor} = render(<Test />);
+	await waitFor(() => {
+		if (lastFrame() !== 'fetched') {
+			throw new Error(`Expected "fetched", got "${lastFrame()}"`);
+		}
+	});
+	t.is(lastFrame(), 'fetched');
+});
+
+test('waitFor rejects on timeout with last assertion error', async t => {
+	function Test() {
+		return <Text>static</Text>;
+	}
+
+	const {waitFor} = render(<Test />);
+	const error = await t.throwsAsync(async () =>
+		waitFor(
+			() => {
+				throw new Error('never passes');
+			},
+			{timeout: 100},
+		),
+	);
+	t.is(error?.message, 'never passes');
+});
+
+test('waitFor rejects with generic message when no frames arrive', async t => {
+	function Test() {
+		return <Text>static</Text>;
+	}
+
+	const {waitFor} = render(<Test />);
+	const error = await t.throwsAsync(async () =>
+		waitFor(
+			() => {
+				throw new Error('not yet');
+			},
+			{timeout: 100},
+		),
+	);
+	t.truthy(error);
 });


### PR DESCRIPTION
This introduces a `waitFor` function similar to the one in the react testing library.

I think it's convenient because it should guarantee that we don't miss frames, and it might make tests faster.

Arguably addresses #22

Usage:
```typescript
  const {lastFrame, waitFor} = render(<MyComponent />);
  await waitFor(() => {
    if (lastFrame() !== 'expected output') {
      throw new Error('not yet');
    }
  });
```

One big caveat: as you can see in the change, `waitFor` isn't compatible with AVA tests. As I understand it this is because AVA stores test failures and reports them later, so the "keep trying until assertions pass or timeout" pattern doesn't work.